### PR TITLE
Url de imagen cambiada en Servicios - Conexion con Cloudinary

### DIFF
--- a/src/pages/Servicios.jsx
+++ b/src/pages/Servicios.jsx
@@ -23,7 +23,7 @@ const Servicios = () => {
           id: card.id,
           titulo: card.titulo,
           precio: card.precio,
-          img: `${API_URL}${card.imagen.url}`,
+          img: card.imagen.url,
           items: card.detalles.map((det) => det.nombre),
         }));
         setCardsData(serviciosFormateados);


### PR DESCRIPTION
Se cambio los datos img del formateo de servicios, cambiando solo a card.imagen.url para establecer conexion unicamente con Cloudinary y no con Strapi